### PR TITLE
adding dynamic templates

### DIFF
--- a/buildkite/jobscript.sh
+++ b/buildkite/jobscript.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pwd; hostname; date
+
+module load julia
+
+echo "Running Tests..."
+julia --project -e 'using Pkg; Pkg.status(); Pkg.test()'
+
+echo "Building Documentation..."
+julia -t 16 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.status(); Pkg.instantiate(); include("docs/make.jl")'

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,15 @@
+steps:
+  - label: ":hammer: Precompile Documentation"
+    commands:
+      - "module load julia"
+      - "julia --project=docs/ --color=yes -e 'using Pkg; Pkg.update(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
+
+  - wait
+
+  - label: ":scroll: Build docs and run tests"
+    env:
+      JULIA_PROJECT: "docs/"
+    commands:
+      - "srun --cpus-per-task=16 --mem=64G --time=1:00:00 --output=.buildkite/log_%j.log --unbuffered jobscript.sh"
+
+  - wait


### PR DESCRIPTION
This PR proposes using [dynamic pipelines](https://buildkite.com/docs/pipelines/defining-steps#dynamic-pipeline-templates) as templates for all repos. Instead of modifying each repo's buildkite pipeline.yml file for any change, we can just modify this one, and any other repo will instead have a pipeline.yml which curls this one.

Such repo-specific pipelines may also add extra build steps.