### PR TITLE
Optionally exclude versions of Julia from CI/CD

### DIFF
--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -16,6 +16,11 @@ on:
         default: "['1.10', '1']" # 1.10.5 is LTS
         required: false
         type: string
+      exclude_versions:
+        description: "Optionally exclude julia versions"
+        required: false
+        default: '[]'
+        type: string
       codecov:
         description: "Whether or not to include codecov"
         default: true
@@ -34,6 +39,7 @@ jobs:
       fail-fast: false
       matrix: # use matrix notation for linux for easily testing more versions/architectures
         version: ${{ fromJSON(inputs.test_versions) }}
+        exclude: ${{ fromJSON(inputs.exclude_versions) }}
         os: [ubuntu-latest]
         arch: ["x64"]
         include:


### PR DESCRIPTION
Our organization CI/CD tests Julia on an array of default versions, which can be overridden by the package maintainer. For example [TraitInterfaces.jl](https://github.com/AlgebraicJulia/TraitInterfaces.jl) and the coming Catlab refactor are not designed around Julia 1.11 and would break. Therefore it makes sense for the maintainer to use the existing parameter `test_versions` to pass in an argument `"['1.11']"` until the AlgebraicJulia CI removes `1.10` from its default testing.

Does it make sense to have an additional `exclude_versions` parameter where package maintainers pass in the version(s) of Julia they want to exclude?