### PR TITLE
Set JULIA_NUM_THREADS to auto

### DIFF
--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -13,7 +13,7 @@ on:
         type: string
       test_versions:
         description: "What versions of julia to test, a JSON array of strings"
-        default: "['1.10', '1']" # 1.10.5 is LTS
+        default: "['1.10', '1']" # Latest patch release of 1.10 is LTS.
         required: false
         type: string
       codecov:
@@ -26,6 +26,8 @@ on:
         default: true
         required: false
         type: boolean
+env:
+  JULIA_NUM_THREADS: "auto"
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
Currently, all jobs across the AJ ecosystem are executed single-threaded.

This results in slower package-precompilation time, since dependencies can typically be executed concurrently. Further, packages which have multi-threading related features cannot test them on the github action environments.

So, this PR sets the JULIA_NUM_THREADS environment variable to "auto".

I also fixed a stale comment about which version of Julia is the LTS.